### PR TITLE
Renamed ambiguous class name ProceedingResult to MonitoringProceedingResult

### DIFF
--- a/FinStat.ViewModel/Monitoring/ProceedingResult.php
+++ b/FinStat.ViewModel/Monitoring/ProceedingResult.php
@@ -1,6 +1,6 @@
 <?php
 
-class ProceedingResult
+class MonitoringProceedingResult
 {
     public $DebtorsAddress;
     public $ProposersAddress;

--- a/FinStatApi/FinstatMonitoringApi.php
+++ b/FinStatApi/FinstatMonitoringApi.php
@@ -165,7 +165,7 @@ class FinstatMonitoringApi extends AbstractFinstatApi
         $response =  array();
         if (!empty($detail->ProceedingResult)) {
             foreach ($detail->ProceedingResult as $element) {
-                $o = new ProceedingResult();
+                $o = new MonitoringProceedingResult();
                 if(!empty($element->DebtorsAddress)) {
                     $array = array();
                     foreach ($element->DebtorsAddress->PersonAddress as $address) {


### PR DESCRIPTION
There was a warning when using the composer package via VCS.
```
    "repositories": [
        { "type": "vcs", "url": "https://github.com/finstat/ClientApi.PHP" }
    ],
    "require": {
        "finstat/client-api": "dev-master"
    }
```

```
Warning: Ambiguous class resolution, "ProceedingResult" was found in both "vendor/finstat/client-api\FinStat.ViewModel\Detail\UltimateResult.php" and "vendor/finstat/client-api\FinStat.ViewModel\Monitoring\ProceedingResult.php", the first will be used.
```
I must have missed it before, so i renamed the class.