### PR TITLE
Requests_Response_Headers compatibility with PHP 8.1+

### DIFF
--- a/FinStat.Client/Requests/Response/Headers.php
+++ b/FinStat.Client/Requests/Response/Headers.php
@@ -24,6 +24,7 @@ class Requests_Response_Headers implements ArrayAccess, IteratorAggregate {
 	 * @param string $key
 	 * @return boolean
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists($key) {
 		$key = strtolower($key);
 		return isset($this->data[$key]);
@@ -35,6 +36,7 @@ class Requests_Response_Headers implements ArrayAccess, IteratorAggregate {
 	 * @param string $key
 	 * @return string Header value
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($key) {
 		$key = strtolower($key);
 		return isset($this->data[$key]) ? $this->data[$key] : null;
@@ -48,6 +50,7 @@ class Requests_Response_Headers implements ArrayAccess, IteratorAggregate {
 	 * @param string $key Header name
 	 * @param string $value Header value
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet($key, $value) {
 		if (is_null($key)) {
 			throw new Requests_Exception('Headers is a dictionary, not a list', 'invalidset');
@@ -70,6 +73,7 @@ class Requests_Response_Headers implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @param string $key
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset($key) {
 		unset($this->data[strtolower($key)]);
 	}
@@ -79,6 +83,7 @@ class Requests_Response_Headers implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @return ArrayIterator
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator() {
 		return new ArrayIterator($this->data);
 	}

--- a/FinStat.Client/Requests/Transport/cURL.php
+++ b/FinStat.Client/Requests/Transport/cURL.php
@@ -90,7 +90,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 				curl_setopt($this->fp, CURLOPT_POST, true);
                 if (empty($headers['Content-Type']) || $headers['Content-Type'] == 'application/x-www-form-urlencoded') {
 					curl_setopt($this->fp, CURLOPT_HTTPHEADER, array('Content-Type: application/x-www-form-urlencoded'));
-				    curl_setopt($this->fp, CURLOPT_POSTFIELDS, http_build_query($data, null, '&'));
+				    curl_setopt($this->fp, CURLOPT_POSTFIELDS, http_build_query($data, '', '&'));
 				} else {
                     curl_setopt($this->fp, CURLOPT_HTTPHEADER, 'Content-Type: ' . $headers['Content-Type']);
 				    curl_setopt($this->fp, CURLOPT_POSTFIELDS, $data);


### PR DESCRIPTION
Got rid of a few deprecations triggered since PHP 8.1.
We use just `FinStatApi` so perhaps others might pop up from different classes.

- `Return type of Requests_Response_Headers::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`

Better fix would be to add return typehints but this would be inconsistent with the rest of the code and I'm not sure what is the lowest PHP version this package aims to be compatible with. This change is still compatible even with PHP 7.0, return typehints would require at least 7.1.

- `http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated`