### PR TITLE
fix error  "Class FinstatApiCz\BankAccount not found"

### DIFF
--- a/FinStatApiCZ/FinstatApi.php
+++ b/FinStatApiCZ/FinstatApi.php
@@ -103,7 +103,7 @@ class FinstatApi extends \BaseFinstatApi
         if (!empty($detail->BankAccounts)) {
             $response->BankAccounts = array();
             foreach ($detail->BankAccounts->BankAccount as $c) {
-                $o = new BankAccount();
+                $o = new \BankAccount();
                 $o->AccountNumber = (string)$c->AccountNumber;
                 $o->PublishedAt = $this->parseDate($c->PublishedAt);
                 $response->BankAccounts[] = $o;


### PR DESCRIPTION
Fixes error in Czech API. Because it uses it's own namespace, class BankAccount is not found properly.
```
 "message": "Class \"FinstatApiCz\\BankAccount\" not found",
 "exception": "Error",
 "file": "/app/vendor/finstat/client-api/FinStatApiCZ/FinstatApi.php",
```